### PR TITLE
Retrieving a webinar throws a serialisation error

### DIFF
--- a/Source/ZoomNet/Models/WebinarSettings.cs
+++ b/Source/ZoomNet/Models/WebinarSettings.cs
@@ -146,6 +146,6 @@ namespace ZoomNet.Models
 		/// Gets or sets the authentication type for users to join a webinar when <see cref="AuthenticatedUsersOnly"/> is set to true.
 		/// </summary>
 		[JsonProperty(PropertyName = "authentication_option")]
-		public bool? AuthenticationType { get; set; }
+		public string AuthenticationType { get; set; }
 	}
 }


### PR DESCRIPTION
Update data type of WebinarSettings.AuthenticationType to string in order to prevent ZoomClient.Webinars.GetAsync() from throwing a serialisation error.