### PR TITLE
Webinars: Add functionality to allow existing webinars to be updated.

### DIFF
--- a/Source/ZoomNet/Resources/IWebinars.cs
+++ b/Source/ZoomNet/Resources/IWebinars.cs
@@ -91,7 +91,7 @@ namespace ZoomNet.Resources
 		/// <returns>
 		/// The async task.
 		/// </returns>
-		Task UpdateScheduledWebinarAsync(long webinarId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
+		Task UpdateScheduledWebinarAsync(long webinarId, string topic = null, string agenda = null, DateTime? start = null, int? duration = null, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Retrieve the details of a webinar.
@@ -120,7 +120,7 @@ namespace ZoomNet.Resources
 		/// <returns>
 		/// The async task.
 		/// </returns>
-		Task UpdateRecurringWebinarAsync(long webinarId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
+		Task UpdateRecurringWebinarAsync(long webinarId, string topic = null, string agenda = null, DateTime? start = null, int? duration = null, RecurrenceInfo recurrence = null, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Delete a webinar.

--- a/Source/ZoomNet/Resources/IWebinars.cs
+++ b/Source/ZoomNet/Resources/IWebinars.cs
@@ -55,7 +55,7 @@ namespace ZoomNet.Resources
 		/// The new webinar.
 		/// </returns>
 		/// <exception cref="System.Exception">Thrown when an exception occured while creating the webinar.</exception>
-		Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
+		Task<Webinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Creates a recurring webinar for a user.

--- a/Source/ZoomNet/Resources/IWebinars.cs
+++ b/Source/ZoomNet/Resources/IWebinars.cs
@@ -55,7 +55,7 @@ namespace ZoomNet.Resources
 		/// The new webinar.
 		/// </returns>
 		/// <exception cref="System.Exception">Thrown when an exception occured while creating the webinar.</exception>
-		Task<Webinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
+		Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Creates a recurring webinar for a user.

--- a/Source/ZoomNet/Resources/IWebinars.cs
+++ b/Source/ZoomNet/Resources/IWebinars.cs
@@ -90,10 +90,8 @@ namespace ZoomNet.Resources
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>
 		/// The async task.
-		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
-		/// A successful update is reported by an HTTP 204 value.
 		/// </returns>
-		Task<System.Net.Http.HttpResponseMessage> UpdateScheduledWebinarAsync(long webinarId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
+		Task UpdateScheduledWebinarAsync(long webinarId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Retrieve the details of a webinar.
@@ -107,7 +105,7 @@ namespace ZoomNet.Resources
 		Task<Webinar> GetAsync(long webinarId, string occurrenceId = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
-		/// Creates an existing recurring webinar for a user.
+		/// Updates an existing recurring webinar for a user.
 		/// </summary>
 		/// <param name="webinarId">The webinar ID.</param>
 		/// <param name="topic">Webinar topic.</param>
@@ -121,10 +119,8 @@ namespace ZoomNet.Resources
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>
 		/// The async task.
-		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
-		/// A successful update is reported by an HTTP 204 value.
 		/// </returns>
-		Task<System.Net.Http.HttpResponseMessage> UpdateRecurringWebinarAsync(long webinarId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
+		Task UpdateRecurringWebinarAsync(long webinarId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Delete a webinar.

--- a/Source/ZoomNet/Resources/IWebinars.cs
+++ b/Source/ZoomNet/Resources/IWebinars.cs
@@ -77,6 +77,25 @@ namespace ZoomNet.Resources
 		Task<RecurringWebinar> CreateRecurringWebinarAsync(string userId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
+		/// Updates an existing scheduled webinar.
+		/// </summary>
+		/// <param name="webinarId">The webinar ID.</param>
+		/// <param name="topic">Webinar topic.</param>
+		/// <param name="agenda">Webinar description.</param>
+		/// <param name="start">Webinar start time.</param>
+		/// <param name="duration">Webinar duration (minutes).</param>
+		/// <param name="password">Password to join the webinar. By default the password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters. This can be updated within Zoom account settings.</param>
+		/// <param name="settings">Webinar settings.</param>
+		/// <param name="trackingFields">Tracking fields.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>
+		/// The async task.
+		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
+		/// A successful update is reported by an HTTP 204 value.
+		/// </returns>
+		Task<System.Net.Http.HttpResponseMessage> UpdateScheduledWebinarAsync(long webinarId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
+
+		/// <summary>
 		/// Retrieve the details of a webinar.
 		/// </summary>
 		/// <param name="webinarId">The webinar ID.</param>
@@ -86,6 +105,26 @@ namespace ZoomNet.Resources
 		/// The <see cref="Webinar" />.
 		/// </returns>
 		Task<Webinar> GetAsync(long webinarId, string occurrenceId = null, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Creates an existing recurring webinar for a user.
+		/// </summary>
+		/// <param name="webinarId">The webinar ID.</param>
+		/// <param name="topic">Webinar topic.</param>
+		/// <param name="agenda">Webinar description.</param>
+		/// <param name="start">Webinar start time.</param>
+		/// <param name="duration">Webinar duration (minutes).</param>
+		/// <param name="recurrence">Recurrence information.</param>
+		/// <param name="password">Password to join the webinar. By default the password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters. This can be updated within Zoom account settings.</param>
+		/// <param name="settings">Webinar settings.</param>
+		/// <param name="trackingFields">Tracking fields.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>
+		/// The async task.
+		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
+		/// A successful update is reported by an HTTP 204 value.
+		/// </returns>
+		Task<System.Net.Http.HttpResponseMessage> UpdateRecurringWebinarAsync(long webinarId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Delete a webinar.

--- a/Source/ZoomNet/Resources/Webinars.cs
+++ b/Source/ZoomNet/Resources/Webinars.cs
@@ -98,7 +98,7 @@ namespace ZoomNet.Resources
 		/// The new webinar.
 		/// </returns>
 		/// <exception cref="System.Exception">Thrown when an exception occured while creating the webinar.</exception>
-		public Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		public Task<Webinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
 		{
 			var data = new JObject()
 			{
@@ -117,7 +117,7 @@ namespace ZoomNet.Resources
 				.PostAsync($"users/{userId}/webinars")
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
-				.AsObject<ScheduledWebinar>();
+				.AsObject<Webinar>();
 		}
 
 		/// <summary>

--- a/Source/ZoomNet/Resources/Webinars.cs
+++ b/Source/ZoomNet/Resources/Webinars.cs
@@ -98,7 +98,7 @@ namespace ZoomNet.Resources
 		/// The new webinar.
 		/// </returns>
 		/// <exception cref="System.Exception">Thrown when an exception occured while creating the webinar.</exception>
-		public Task<Webinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		public Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
 		{
 			var data = new JObject()
 			{
@@ -117,7 +117,7 @@ namespace ZoomNet.Resources
 				.PostAsync($"users/{userId}/webinars")
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
-				.AsObject<Webinar>();
+				.AsObject<ScheduledWebinar>();
 		}
 
 		/// <summary>

--- a/Source/ZoomNet/Resources/Webinars.cs
+++ b/Source/ZoomNet/Resources/Webinars.cs
@@ -90,7 +90,7 @@ namespace ZoomNet.Resources
 		/// <param name="agenda">Webinar description.</param>
 		/// <param name="start">Webinar start time.</param>
 		/// <param name="duration">Webinar duration (minutes).</param>
-		/// <param name="password">Password to join the webinar. Password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters.</param>
+		/// <param name="password">Password to join the webinar. By default the password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters. This can be updated within Zoom account settings.</param>
 		/// <param name="settings">Webinar settings.</param>
 		/// <param name="trackingFields">Tracking fields.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
@@ -121,6 +121,45 @@ namespace ZoomNet.Resources
 		}
 
 		/// <summary>
+		/// Updates an existing scheduled webinar.
+		/// </summary>
+		/// <param name="webinarId">The webinar ID.</param>
+		/// <param name="topic">Webinar topic.</param>
+		/// <param name="agenda">Webinar description.</param>
+		/// <param name="start">Webinar start time.</param>
+		/// <param name="duration">Webinar duration (minutes).</param>
+		/// <param name="password">Password to join the webinar. By default the password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters. This can be updated within Zoom account settings.</param>
+		/// <param name="settings">Webinar settings.</param>
+		/// <param name="trackingFields">Tracking fields.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>
+		/// The async task.
+		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
+		/// A successful update is reported by an HTTP 204 value.
+		/// </returns>
+		public Task<System.Net.Http.HttpResponseMessage> UpdateScheduledWebinarAsync(long webinarId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		{
+			var data = new JObject()
+			{
+				{ "type", 5 }
+			};
+			data.AddPropertyIfValue("topic", topic);
+			data.AddPropertyIfValue("agenda", agenda);
+			data.AddPropertyIfValue("password", password);
+			data.AddPropertyIfValue("start_time", start.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+			data.AddPropertyIfValue("duration", duration);
+			data.AddPropertyIfValue("timezone", "UTC");
+			data.AddPropertyIfValue("settings", settings);
+			data.AddPropertyIfValue("tracking_fields", trackingFields?.Select(tf => new JObject() { { "field", tf.Key }, { "value", tf.Value } }));
+
+			return _client
+				.PatchAsync($"webinars/{webinarId}")
+				.WithJsonBody(data)
+				.WithCancellationToken(cancellationToken)
+				.AsMessage();
+		}
+
+		/// <summary>
 		/// Creates a recurring webinar for a user.
 		/// </summary>
 		/// <param name="userId">The user Id or email address.</param>
@@ -129,7 +168,7 @@ namespace ZoomNet.Resources
 		/// <param name="start">Webinar start time.</param>
 		/// <param name="duration">Webinar duration (minutes).</param>
 		/// <param name="recurrence">Recurrence information.</param>
-		/// <param name="password">Password to join the webinar. Password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters.</param>
+		/// <param name="password">Password to join the webinar. By default the password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters. This can be updated within Zoom account settings.</param>
 		/// <param name="settings">Webinar settings.</param>
 		/// <param name="trackingFields">Tracking fields.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
@@ -160,6 +199,47 @@ namespace ZoomNet.Resources
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
 				.AsObject<RecurringWebinar>();
+		}
+
+		/// <summary>
+		/// Creates an existing recurring webinar for a user.
+		/// </summary>
+		/// <param name="webinarId">The webinar ID.</param>
+		/// <param name="topic">Webinar topic.</param>
+		/// <param name="agenda">Webinar description.</param>
+		/// <param name="start">Webinar start time.</param>
+		/// <param name="duration">Webinar duration (minutes).</param>
+		/// <param name="recurrence">Recurrence information.</param>
+		/// <param name="password">Password to join the webinar. By default the password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters. This can be updated within Zoom account settings.</param>
+		/// <param name="settings">Webinar settings.</param>
+		/// <param name="trackingFields">Tracking fields.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>
+		/// The async task.
+		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
+		/// A successful update is reported by an HTTP 204 value.
+		/// </returns>
+		public Task<System.Net.Http.HttpResponseMessage> UpdateRecurringWebinarAsync(long webinarId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		{
+			var data = new JObject()
+			{
+				{ "type", start.HasValue ? 9 : 6 }
+			};
+			data.AddPropertyIfValue("topic", topic);
+			data.AddPropertyIfValue("agenda", agenda);
+			data.AddPropertyIfValue("password", password);
+			data.AddPropertyIfValue("start_time", start?.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+			data.AddPropertyIfValue("duration", duration);
+			data.AddPropertyIfValue("recurrence", recurrence);
+			data.AddPropertyIfValue("timezone", "UTC");
+			data.AddPropertyIfValue("settings", settings);
+			data.AddPropertyIfValue("tracking_fields", trackingFields?.Select(tf => new JObject() { { "field", tf.Key }, { "value", tf.Value } }));
+
+			return _client
+				.PatchAsync($"webinars/{webinarId}")
+				.WithJsonBody(data)
+				.WithCancellationToken(cancellationToken)
+				.AsMessage();
 		}
 
 		/// <summary>

--- a/Source/ZoomNet/Resources/Webinars.cs
+++ b/Source/ZoomNet/Resources/Webinars.cs
@@ -137,7 +137,7 @@ namespace ZoomNet.Resources
 		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
 		/// A successful update is reported by an HTTP 204 value.
 		/// </returns>
-		public Task<System.Net.Http.HttpResponseMessage> UpdateScheduledWebinarAsync(long webinarId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		public Task UpdateScheduledWebinarAsync(long webinarId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
 		{
 			var data = new JObject()
 			{
@@ -152,11 +152,19 @@ namespace ZoomNet.Resources
 			data.AddPropertyIfValue("settings", settings);
 			data.AddPropertyIfValue("tracking_fields", trackingFields?.Select(tf => new JObject() { { "field", tf.Key }, { "value", tf.Value } }));
 
-			return _client
+			var task = _client
 				.PatchAsync($"webinars/{webinarId}")
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
 				.AsMessage();
+
+			if (task.Result.StatusCode == System.Net.HttpStatusCode.OK)
+			{
+				// Zoom returns an HTTP 200 message when there is no webinar subscription and instead returns a 204 after a successful update
+				throw new NotSupportedException("Webinar subscription plan is missing. Enable webinar for this user once the subscription is added");
+			}
+
+			return task;
 		}
 
 		/// <summary>
@@ -202,7 +210,7 @@ namespace ZoomNet.Resources
 		}
 
 		/// <summary>
-		/// Creates an existing recurring webinar for a user.
+		/// Updates an existing recurring webinar for a user.
 		/// </summary>
 		/// <param name="webinarId">The webinar ID.</param>
 		/// <param name="topic">Webinar topic.</param>
@@ -219,7 +227,7 @@ namespace ZoomNet.Resources
 		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
 		/// A successful update is reported by an HTTP 204 value.
 		/// </returns>
-		public Task<System.Net.Http.HttpResponseMessage> UpdateRecurringWebinarAsync(long webinarId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		public Task UpdateRecurringWebinarAsync(long webinarId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
 		{
 			var data = new JObject()
 			{
@@ -235,11 +243,19 @@ namespace ZoomNet.Resources
 			data.AddPropertyIfValue("settings", settings);
 			data.AddPropertyIfValue("tracking_fields", trackingFields?.Select(tf => new JObject() { { "field", tf.Key }, { "value", tf.Value } }));
 
-			return _client
+			var task = _client
 				.PatchAsync($"webinars/{webinarId}")
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
 				.AsMessage();
+
+			if (task.Result.StatusCode == System.Net.HttpStatusCode.OK)
+			{
+				// Zoom returns an HTTP 200 message when there is no webinar subscription and instead returns a 204 after a successful update
+				throw new NotSupportedException("Webinar subscription plan is missing. Enable webinar for this user once the subscription is added");
+			}
+
+			return task;
 		}
 
 		/// <summary>

--- a/Source/ZoomNet/Resources/Webinars.cs
+++ b/Source/ZoomNet/Resources/Webinars.cs
@@ -239,12 +239,6 @@ namespace ZoomNet.Resources
 				.AsMessage()
 				.ConfigureAwait(false);
 
-			switch (result.StatusCode)
-			{
-				case System.Net.HttpStatusCode.OK:
-					break;
-			}
-
 			if (result.StatusCode == System.Net.HttpStatusCode.OK)
 			{
 				// Zoom returns an HTTP 200 message when there is no webinar subscription and instead returns a 204 after a successful update

--- a/Source/ZoomNet/Resources/Webinars.cs
+++ b/Source/ZoomNet/Resources/Webinars.cs
@@ -134,37 +134,31 @@ namespace ZoomNet.Resources
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>
 		/// The async task.
-		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
-		/// A successful update is reported by an HTTP 204 value.
 		/// </returns>
-		public Task UpdateScheduledWebinarAsync(long webinarId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		public async Task UpdateScheduledWebinarAsync(long webinarId, string topic = null, string agenda = null, DateTime? start = null, int? duration = null, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
 		{
-			var data = new JObject()
-			{
-				{ "type", 5 }
-			};
+			var data = new JObject();
 			data.AddPropertyIfValue("topic", topic);
 			data.AddPropertyIfValue("agenda", agenda);
 			data.AddPropertyIfValue("password", password);
-			data.AddPropertyIfValue("start_time", start.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+			data.AddPropertyIfValue("start_time", start?.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"));
 			data.AddPropertyIfValue("duration", duration);
-			data.AddPropertyIfValue("timezone", "UTC");
+			if (start.HasValue) data.Add("timezone", "UTC");
 			data.AddPropertyIfValue("settings", settings);
 			data.AddPropertyIfValue("tracking_fields", trackingFields?.Select(tf => new JObject() { { "field", tf.Key }, { "value", tf.Value } }));
 
-			var task = _client
+			var result = await _client
 				.PatchAsync($"webinars/{webinarId}")
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
-				.AsMessage();
+				.AsMessage()
+				.ConfigureAwait(false);
 
-			if (task.Result.StatusCode == System.Net.HttpStatusCode.OK)
+			if (result.StatusCode == System.Net.HttpStatusCode.OK)
 			{
 				// Zoom returns an HTTP 200 message when there is no webinar subscription and instead returns a 204 after a successful update
 				throw new NotSupportedException("Webinar subscription plan is missing. Enable webinar for this user once the subscription is added");
 			}
-
-			return task;
 		}
 
 		/// <summary>
@@ -224,38 +218,38 @@ namespace ZoomNet.Resources
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>
 		/// The async task.
-		/// Zoom will return an HTTP 200 response when there is no webinar subscription present.
-		/// A successful update is reported by an HTTP 204 value.
 		/// </returns>
-		public Task UpdateRecurringWebinarAsync(long webinarId, string topic, string agenda, DateTime? start, int duration, RecurrenceInfo recurrence, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		public async Task UpdateRecurringWebinarAsync(long webinarId, string topic = null, string agenda = null, DateTime? start = null, int? duration = null, RecurrenceInfo recurrence = null, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
 		{
-			var data = new JObject()
-			{
-				{ "type", start.HasValue ? 9 : 6 }
-			};
+			var data = new JObject();
 			data.AddPropertyIfValue("topic", topic);
 			data.AddPropertyIfValue("agenda", agenda);
 			data.AddPropertyIfValue("password", password);
 			data.AddPropertyIfValue("start_time", start?.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'"));
 			data.AddPropertyIfValue("duration", duration);
 			data.AddPropertyIfValue("recurrence", recurrence);
-			data.AddPropertyIfValue("timezone", "UTC");
+			if (start.HasValue) data.Add("timezone", "UTC");
 			data.AddPropertyIfValue("settings", settings);
 			data.AddPropertyIfValue("tracking_fields", trackingFields?.Select(tf => new JObject() { { "field", tf.Key }, { "value", tf.Value } }));
 
-			var task = _client
+			var result = await _client
 				.PatchAsync($"webinars/{webinarId}")
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
-				.AsMessage();
+				.AsMessage()
+				.ConfigureAwait(false);
 
-			if (task.Result.StatusCode == System.Net.HttpStatusCode.OK)
+			switch (result.StatusCode)
+			{
+				case System.Net.HttpStatusCode.OK:
+					break;
+			}
+
+			if (result.StatusCode == System.Net.HttpStatusCode.OK)
 			{
 				// Zoom returns an HTTP 200 message when there is no webinar subscription and instead returns a 204 after a successful update
 				throw new NotSupportedException("Webinar subscription plan is missing. Enable webinar for this user once the subscription is added");
 			}
-
-			return task;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Per issue #80 it's not possible to update an existing webinar using ZoomNet.

Added and tested this functionality as per the API reference [here](https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/webinarupdate).

Also updated the wording of the "password" field. While the default restrictions match [a-z A-Z 0-9 @ - _ *] with a max of 10 characters, it's possible to update these restrictions within a Zoom account as noted [here](https://marketplace.zoom.us/docs/api-reference/zoom-api/accounts/accountsettings).