### PR TITLE
Add templateId to CreateScheduledWebinarAsync

### DIFF
--- a/Source/ZoomNet.IntegrationTests/Tests/Webinars.cs
+++ b/Source/ZoomNet.IntegrationTests/Tests/Webinars.cs
@@ -45,7 +45,7 @@ namespace ZoomNet.IntegrationTests.Tests
 			// Scheduled webinar
 			var start = DateTime.UtcNow.AddMonths(1);
 			var duration = 30;
-			var newScheduledWebinar = await client.Webinars.CreateScheduledWebinarAsync(userId, "ZoomNet Integration Testing: scheduled webinar", "The agenda", start, duration, "p@ss!w0rd", settings, trackingFields, cancellationToken).ConfigureAwait(false);
+			var newScheduledWebinar = await client.Webinars.CreateScheduledWebinarAsync(userId, "ZoomNet Integration Testing: scheduled webinar", "The agenda", start, duration, "p@ss!w0rd", settings, trackingFields, cancellationToken: cancellationToken).ConfigureAwait(false);
 			await log.WriteLineAsync($"Scheduled webinar {newScheduledWebinar.Id} created").ConfigureAwait(false);
 
 			await client.Webinars.DeleteAsync(newScheduledWebinar.Id, null, false, cancellationToken).ConfigureAwait(false);

--- a/Source/ZoomNet/Resources/IWebinars.cs
+++ b/Source/ZoomNet/Resources/IWebinars.cs
@@ -51,11 +51,12 @@ namespace ZoomNet.Resources
 		/// <param name="settings">Webinar settings.</param>
 		/// <param name="trackingFields">Tracking fields.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <param name="templateId">Template Identifer.</param>
 		/// <returns>
 		/// The new webinar.
 		/// </returns>
 		/// <exception cref="System.Exception">Thrown when an exception occured while creating the webinar.</exception>
-		Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default);
+		Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default, string templateId = null);
 
 		/// <summary>
 		/// Creates a recurring webinar for a user.

--- a/Source/ZoomNet/Resources/IWebinars.cs
+++ b/Source/ZoomNet/Resources/IWebinars.cs
@@ -50,13 +50,13 @@ namespace ZoomNet.Resources
 		/// <param name="password">Password to join the webinar. Password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters.</param>
 		/// <param name="settings">Webinar settings.</param>
 		/// <param name="trackingFields">Tracking fields.</param>
-		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <param name="templateId">Template Identifer.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>
 		/// The new webinar.
 		/// </returns>
 		/// <exception cref="System.Exception">Thrown when an exception occured while creating the webinar.</exception>
-		Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default, string templateId = null);
+		Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, string templateId = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Creates a recurring webinar for a user.

--- a/Source/ZoomNet/Resources/Webinars.cs
+++ b/Source/ZoomNet/Resources/Webinars.cs
@@ -93,13 +93,13 @@ namespace ZoomNet.Resources
 		/// <param name="password">Password to join the webinar. Password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters.</param>
 		/// <param name="settings">Webinar settings.</param>
 		/// <param name="trackingFields">Tracking fields.</param>
-		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <param name="templateId">Template Identifer.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>
 		/// The new webinar.
 		/// </returns>
 		/// <exception cref="System.Exception">Thrown when an exception occured while creating the webinar.</exception>
-		public Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default, string templateId = null)
+		public Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, string templateId = null, CancellationToken cancellationToken = default)
 		{
 			var data = new JObject()
 			{
@@ -114,10 +114,9 @@ namespace ZoomNet.Resources
 			data.AddPropertyIfValue("settings", settings);
 			data.AddPropertyIfValue("tracking_fields", trackingFields?.Select(tf => new JObject() { { "field", tf.Key }, { "value", tf.Value } }));
 
-			string templateIdUrl = string.IsNullOrWhiteSpace(templateId) ? string.Empty : $"?template_id={templateId}";
-
 			return _client
-				.PostAsync($"users/{userId}/webinars{templateIdUrl}")
+				.PostAsync($"users/{userId}/webinars")
+				.WithArgument("template_id", templateId)
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
 				.AsObject<ScheduledWebinar>();

--- a/Source/ZoomNet/Resources/Webinars.cs
+++ b/Source/ZoomNet/Resources/Webinars.cs
@@ -94,11 +94,12 @@ namespace ZoomNet.Resources
 		/// <param name="settings">Webinar settings.</param>
 		/// <param name="trackingFields">Tracking fields.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <param name="templateId">Template Identifer.</param>
 		/// <returns>
 		/// The new webinar.
 		/// </returns>
 		/// <exception cref="System.Exception">Thrown when an exception occured while creating the webinar.</exception>
-		public Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default)
+		public Task<ScheduledWebinar> CreateScheduledWebinarAsync(string userId, string topic, string agenda, DateTime start, int duration, string password = null, WebinarSettings settings = null, IDictionary<string, string> trackingFields = null, CancellationToken cancellationToken = default, string templateId = null)
 		{
 			var data = new JObject()
 			{
@@ -113,8 +114,10 @@ namespace ZoomNet.Resources
 			data.AddPropertyIfValue("settings", settings);
 			data.AddPropertyIfValue("tracking_fields", trackingFields?.Select(tf => new JObject() { { "field", tf.Key }, { "value", tf.Value } }));
 
+			string templateIdUrl = string.IsNullOrWhiteSpace(templateId) ? string.Empty : $"?template_id={templateId}";
+
 			return _client
-				.PostAsync($"users/{userId}/webinars")
+				.PostAsync($"users/{userId}/webinars{templateIdUrl}")
 				.WithJsonBody(data)
 				.WithCancellationToken(cancellationToken)
 				.AsObject<ScheduledWebinar>();


### PR DESCRIPTION
OK, so this is my **FIRST ever pull request to a project which isn't mine** - so be kind! eeep!

I've just started on a new project which uses your excellent nuget package, however, my client has set up a templates in Zoom and wishes to use a template when the Zoom webinar is created via the Zoom API.

My research has lead me to this:
https://devforum.zoom.us/t/create-webinar-through-api-using-webinar-template/33013/4
... aka the templateId should be passed to the API as a parameter:
`https://api.zoom.us/v2/users/{userId}/webinars?template_id={templateId}`
... which the Zoom team haven't put in the official documentation.

There is, however, an existing "[List Webinar Templates](https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/listwebinartemplates)" end point which provides the templateIds (but again, only that above link exists in how to use them).

Can you consider my Pull Request please?
My only other point I should make is that I did look at the tests solution, but since it's an integration test, the test's templateId will need to exist before it's used in the test runs - so I didn't update the integration test due to this.