### PR TITLE
Remove pagination when searching for recordings against a specific meeting

### DIFF
--- a/Source/ZoomNet/Resources/CloudRecordings.cs
+++ b/Source/ZoomNet/Resources/CloudRecordings.cs
@@ -95,54 +95,17 @@ namespace ZoomNet.Resources
 		}
 
 		/// <summary>
-		/// Retrieve all cloud recordings for a meeting.
+		/// Retrieve all cloud recordings for a meeting or webinar.
 		/// </summary>
 		/// <param name="meetingId">The meeting Id or UUID.</param>
-		/// <param name="recordsPerPage">The number of records returned within a single API call.</param>
-		/// <param name="page">The current page number of returned records.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
-		/// <returns>
-		/// An array of <see cref="Recording">recordings</see>.
-		/// </returns>
-		[Obsolete("Zoom is in the process of deprecating the \"page number\" and \"page count\" fields.")]
-		public Task<PaginatedResponse<Recording>> GetRecordingsAsync(string meetingId, int recordsPerPage = 30, int page = 1, CancellationToken cancellationToken = default)
+		/// <returns>Details of recordings made for a particular meeding or webinar.</returns>
+		public Task<Recording> GetRecordingsAsync(string meetingId, CancellationToken cancellationToken = default)
 		{
-			if (recordsPerPage < 1 || recordsPerPage > 300)
-			{
-				throw new ArgumentOutOfRangeException(nameof(recordsPerPage), "Records per page must be between 1 and 300");
-			}
-
 			return _client
 				.GetAsync($"meetings/{meetingId}/recordings")
-				.WithArgument("page_size", recordsPerPage)
-				.WithArgument("page", page)
 				.WithCancellationToken(cancellationToken)
-				.AsPaginatedResponse<Recording>("meetings");
-		}
-
-		/// <summary>
-		/// Retrieve all cloud recordings for a user.
-		/// </summary>
-		/// <param name="meetingId">The meeting Id or UUID.</param>
-		/// <param name="recordsPerPage">The number of records returned within a single API call.</param>
-		/// <param name="pagingToken">The paging token.</param>
-		/// <param name="cancellationToken">The cancellation token.</param>
-		/// <returns>
-		/// An array of <see cref="Recording">recordings</see>.
-		/// </returns>
-		public Task<PaginatedResponseWithToken<Recording>> GetRecordingsAsync(string meetingId, int recordsPerPage = 30, string pagingToken = null, CancellationToken cancellationToken = default)
-		{
-			if (recordsPerPage < 1 || recordsPerPage > 300)
-			{
-				throw new ArgumentOutOfRangeException(nameof(recordsPerPage), "Records per page must be between 1 and 300");
-			}
-
-			return _client
-				.GetAsync($"meetings/{meetingId}/recordings")
-				.WithArgument("page_size", recordsPerPage)
-				.WithArgument("next_page_token", pagingToken)
-				.WithCancellationToken(cancellationToken)
-				.AsPaginatedResponseWithToken<Recording>("meetings");
+				.AsObject<Recording>();
 		}
 
 		/// <summary>

--- a/Source/ZoomNet/Resources/ICloudRecordings.cs
+++ b/Source/ZoomNet/Resources/ICloudRecordings.cs
@@ -46,29 +46,12 @@ namespace ZoomNet.Resources
 		Task<PaginatedResponseWithTokenAndDateRange<Recording>> GetRecordingsForUserAsync(string userId, bool queryTrash = false, DateTime? from = null, DateTime? to = null, int recordsPerPage = 30, string pagingToken = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
-		/// Retrieve all cloud recordings for a meeting.
+		/// Retrieve all cloud recordings for a meeting or webinar.
 		/// </summary>
 		/// <param name="meetingId">The meeting Id or UUID.</param>
-		/// <param name="recordsPerPage">The number of records returned within a single API call.</param>
-		/// <param name="page">The current page number of returned records.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
-		/// <returns>
-		/// An array of <see cref="Recording">recordings</see>.
-		/// </returns>
-		[Obsolete("Zoom is in the process of deprecating the \"page number\" and \"page count\" fields.")]
-		Task<PaginatedResponse<Recording>> GetRecordingsAsync(string meetingId, int recordsPerPage = 30, int page = 1, CancellationToken cancellationToken = default);
-
-		/// <summary>
-		/// Retrieve all cloud recordings for a meeting.
-		/// </summary>
-		/// <param name="meetingId">The meeting Id or UUID.</param>
-		/// <param name="recordsPerPage">The number of records returned within a single API call.</param>
-		/// <param name="pagingToken">The paging token.</param>
-		/// <param name="cancellationToken">The cancellation token.</param>
-		/// <returns>
-		/// An array of <see cref="Recording">recordings</see>.
-		/// </returns>
-		Task<PaginatedResponseWithToken<Recording>> GetRecordingsAsync(string meetingId, int recordsPerPage = 30, string pagingToken = null, CancellationToken cancellationToken = default);
+		/// <returns>Details of recordings made for a particular meeding or webinar.</returns>
+		Task<Recording> GetRecordingsAsync(string meetingId, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Move recording files for a meeting to trash.


### PR DESCRIPTION
Per issue #101 Zoom doesn't use pagination when returning recordings listed against a specific meeting/webinar id.

Have removed pagination functions/params within CloudRecordings.GetRecordingsAsync() and replaced with a single function returning the correct data type.