### PR TITLE
Fixed ZoomRoomIssueDetails

### DIFF
--- a/Source/ZoomNet/Models/ZoomRoomIssueDetails.cs
+++ b/Source/ZoomNet/Models/ZoomRoomIssueDetails.cs
@@ -34,7 +34,7 @@ namespace ZoomNet.Models
 		/// * Scheduling Display.<br/>
 		/// </summary>
 		/// <value>The Issue name.</value>
-		[JsonProperty(PropertyName = "issue_name")]
+		[JsonProperty(PropertyName = "issue")]
 		public IssueType IssueType { get; set; }
 
 		/// <summary>
@@ -42,6 +42,6 @@ namespace ZoomNet.Models
 		/// </summary>
 		/// <value>The time the issue appeared.</value>
 		[JsonProperty(PropertyName = "time")]
-		public DateTime ZoomRoomsCount { get; set; }
+		public DateTime Time { get; set; }
 	}
 }


### PR DESCRIPTION
1. I was getting bad feedback from the room issues API endpoints because of bad JsonProperties, so I fixed those
2. Some of the properties were badly named so I corrected them
3. I understand the decision to represent the IssueType as an enum, but I'm concerned about Zoom eventually adding new values, changing existing values, or even implementing localization. I elected to remove the IssueType enum and instead use a string, but I'll understand if you want this part reverted.