### PR TITLE
CloudRecording - Fixed datetime format for CloudRecording ressource

### DIFF
--- a/Source/ZoomNet/Resources/CloudRecordings.cs
+++ b/Source/ZoomNet/Resources/CloudRecordings.cs
@@ -55,8 +55,8 @@ namespace ZoomNet.Resources
 			return _client
 				.GetAsync($"users/{userId}/recordings")
 				.WithArgument("trash", queryTrash.ToString().ToLower())
-				.WithArgument("from", from?.ToString("yyyy-mm-dd"))
-				.WithArgument("to", to?.ToString("yyyy-mm-dd"))
+				.WithArgument("from", from?.ToString("yyyy-MM-dd"))
+				.WithArgument("to", to?.ToString("yyyy-MM-dd"))
 				.WithArgument("page_size", recordsPerPage)
 				.WithArgument("page_number", page)
 				.WithCancellationToken(cancellationToken)
@@ -86,8 +86,8 @@ namespace ZoomNet.Resources
 			return _client
 				.GetAsync($"users/{userId}/recordings")
 				.WithArgument("trash", queryTrash.ToString().ToLower())
-				.WithArgument("from", from?.ToString("yyyy-mm-dd"))
-				.WithArgument("to", to?.ToString("yyyy-mm-dd"))
+				.WithArgument("from", from?.ToString("yyyy-MM-dd"))
+				.WithArgument("to", to?.ToString("yyyy-MM-dd"))
 				.WithArgument("page_size", recordsPerPage)
 				.WithArgument("next_page_token", pagingToken)
 				.WithCancellationToken(cancellationToken)


### PR DESCRIPTION
Fixed an issue where `DateTime` format was using `mm` for month when it was supposed to be `MM`.