### PR TITLE
Added custom attributes support to User update.

### DIFF
--- a/Source/ZoomNet.IntegrationTests/Tests/Users.cs
+++ b/Source/ZoomNet.IntegrationTests/Tests/Users.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,13 @@ namespace ZoomNet.IntegrationTests.Tests
 			if (cancellationToken.IsCancellationRequested) return;
 
 			await log.WriteLineAsync("\n***** USERS *****\n").ConfigureAwait(false);
+
+			// UPDATE CUSTOM ATTRIBUTES
+			await client.Users.UpdateAsync(myUser.Id,
+				customAttributes: new List<CustomAttribute> { new CustomAttribute { Key = "TestKey1", Name = "TestName1", Value = "TestValue1" } },
+				cancellationToken: cancellationToken).ConfigureAwait(false);
+			await log.WriteLineAsync("My user custom attributes were updated").ConfigureAwait(false);
+			await Task.Delay(500, cancellationToken).ConfigureAwait(false);
 
 			// UPDATE MY USER
 			await client.Users.UpdateAsync(myUser.Id,

--- a/Source/ZoomNet/OAuthConnectionInfo.cs
+++ b/Source/ZoomNet/OAuthConnectionInfo.cs
@@ -156,7 +156,6 @@ namespace ZoomNet
 			if (string.IsNullOrEmpty(clientId)) throw new ArgumentNullException(nameof(clientId));
 			if (string.IsNullOrEmpty(clientSecret)) throw new ArgumentNullException(nameof(clientSecret));
 			if (string.IsNullOrEmpty(refreshToken)) throw new ArgumentNullException(nameof(refreshToken));
-			if (string.IsNullOrEmpty(accessToken)) throw new ArgumentNullException(nameof(accessToken));
 
 			ClientId = clientId;
 			ClientSecret = clientSecret;

--- a/Source/ZoomNet/Resources/IUsers.cs
+++ b/Source/ZoomNet/Resources/IUsers.cs
@@ -81,7 +81,7 @@ namespace ZoomNet.Resources
 		/// <param name="personalMeetingRoomName">Personal meeting room name.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>The async task.</returns>
-		Task UpdateAsync(string userId, string firstName = null, string lastName = null, string company = null, string department = null, string groupId = null, string hostKey = null, string jobTitle = null, string language = null, string location = null, string manager = null, IEnumerable<PhoneNumber> phoneNumbers = null, string pmi = null, string pronouns = null, PronounDisplayType? pronounsDisplay = null, TimeZones? timezone = null, UserType? type = null, bool? usePmi = null, string personalMeetingRoomName = null, CancellationToken cancellationToken = default);
+		Task UpdateAsync(string userId, string firstName = null, string lastName = null, string company = null, string department = null, string groupId = null, string hostKey = null, string jobTitle = null, string language = null, string location = null, string manager = null, IEnumerable<PhoneNumber> phoneNumbers = null, string pmi = null, string pronouns = null, PronounDisplayType? pronounsDisplay = null, TimeZones? timezone = null, UserType? type = null, bool? usePmi = null, string personalMeetingRoomName = null, IEnumerable<CustomAttribute> customAttributes = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Retrieve the information of a specific user on a Zoom account.

--- a/Source/ZoomNet/Resources/IUsers.cs
+++ b/Source/ZoomNet/Resources/IUsers.cs
@@ -79,6 +79,7 @@ namespace ZoomNet.Resources
 		/// <param name="type">The type of user.</param>
 		/// <param name="usePmi">Use Personal Meeting ID for instant meetings.</param>
 		/// <param name="personalMeetingRoomName">Personal meeting room name.</param>
+		/// <param name="customAttributes">Custom Attributes.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <returns>The async task.</returns>
 		Task UpdateAsync(string userId, string firstName = null, string lastName = null, string company = null, string department = null, string groupId = null, string hostKey = null, string jobTitle = null, string language = null, string location = null, string manager = null, IEnumerable<PhoneNumber> phoneNumbers = null, string pmi = null, string pronouns = null, PronounDisplayType? pronounsDisplay = null, TimeZones? timezone = null, UserType? type = null, bool? usePmi = null, string personalMeetingRoomName = null, IEnumerable<CustomAttribute> customAttributes = null, CancellationToken cancellationToken = default);

--- a/Source/ZoomNet/Resources/Users.cs
+++ b/Source/ZoomNet/Resources/Users.cs
@@ -126,7 +126,7 @@ namespace ZoomNet.Resources
 		}
 
 		/// <inheritdoc/>
-		public Task UpdateAsync(string userId, string firstName = null, string lastName = null, string company = null, string department = null, string groupId = null, string hostKey = null, string jobTitle = null, string language = null, string location = null, string manager = null, IEnumerable<PhoneNumber> phoneNumbers = null, string pmi = null, string pronouns = null, PronounDisplayType? pronounsDisplay = null, TimeZones? timezone = null, UserType? type = null, bool? usePmi = null, string personalMeetingRoomName = null, CancellationToken cancellationToken = default)
+		public Task UpdateAsync(string userId, string firstName = null, string lastName = null, string company = null, string department = null, string groupId = null, string hostKey = null, string jobTitle = null, string language = null, string location = null, string manager = null, IEnumerable<PhoneNumber> phoneNumbers = null, string pmi = null, string pronouns = null, PronounDisplayType? pronounsDisplay = null, TimeZones? timezone = null, UserType? type = null, bool? usePmi = null, string personalMeetingRoomName = null, IEnumerable<CustomAttribute> customAttributes = null, CancellationToken cancellationToken = default)
 		{
 			var data = new JsonObject
 			{
@@ -148,6 +148,7 @@ namespace ZoomNet.Resources
 				{ "type", type?.ToEnumString() },
 				{ "use_pmi", usePmi },
 				{ "vanity_name", personalMeetingRoomName },
+				{ "custom_attributes", customAttributes?.ToArray() }
 			};
 
 			return _client


### PR DESCRIPTION
- Added custom attributes support to User update.
- Allowed authorisation to work when only a refresh token is remembered and not an access token - causes the first step to be refreshing the access token.