### PR TITLE
Add support for webinar participants report

### DIFF
--- a/Source/ZoomNet.IntegrationTests/Tests/Reports.cs
+++ b/Source/ZoomNet.IntegrationTests/Tests/Reports.cs
@@ -35,6 +35,19 @@ namespace ZoomNet.IntegrationTests.Tests
 			}
 
 			await log.WriteLineAsync($"There are {pastMeetings.Records.Length} past instances of meetings with a total of {totalParticipants} participants for this user.").ConfigureAwait(false);
+
+			// GET ALL THE WEBINARS
+			var pastWebinars = await client.Webinars.GetAllAsync(myUser.Id, 30, null, cancellationToken).ConfigureAwait(false);
+
+			totalParticipants = 0;
+			foreach (var webinar in pastWebinars.Records)
+			{
+				var paginatedParticipants = await client.Reports.GetWebinarParticipantsAsync(webinar.Uuid, 30, null, cancellationToken);
+				totalParticipants += paginatedParticipants.TotalRecords;
+			}
+
+			await log.WriteLineAsync($"There are {pastWebinars.Records.Length} past instances of webinar with a total of {totalParticipants} participants for this user.").ConfigureAwait(false);
+
 		}
 	}
 }

--- a/Source/ZoomNet.IntegrationTests/Tests/Reports.cs
+++ b/Source/ZoomNet.IntegrationTests/Tests/Reports.cs
@@ -47,7 +47,6 @@ namespace ZoomNet.IntegrationTests.Tests
 			}
 
 			await log.WriteLineAsync($"There are {pastWebinars.Records.Length} past instances of webinar with a total of {totalParticipants} participants for this user.").ConfigureAwait(false);
-
 		}
 	}
 }

--- a/Source/ZoomNet/Models/ReportWebinarParticipant.cs
+++ b/Source/ZoomNet/Models/ReportWebinarParticipant.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace ZoomNet.Models
+{
+	/// <summary>
+	/// Metrics of a participant.
+	/// </summary>
+	public class ReportWebinarParticipant : ReportParticipant
+	{
+		/// <summary>
+		/// Gets or sets the RegistrantID of the participant.
+		/// </summary>
+		/// <value>
+		/// The RegistrantID of the participant. Only returned if registrant_id is included in the include_fields query parameter.
+		/// </value>
+		[JsonPropertyName("registrant_id")]
+		public string RegistrantId { get; set; }
+	}
+}

--- a/Source/ZoomNet/Resources/IReports.cs
+++ b/Source/ZoomNet/Resources/IReports.cs
@@ -49,6 +49,22 @@ namespace ZoomNet.Resources
 		Task<PaginatedResponseWithToken<PastMeeting>> GetMeetingsAsync(string userId, DateTime from, DateTime to, ReportMeetingType type = ReportMeetingType.Past, int pageSize = 30, string pageToken = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
+		/// Get a list of participants from past webinars with two or more participants. To see a list of participants for webinars with one participant use <see cref="IDashboards.GetMeetingParticipantsAsync"/>.
+		/// </summary>
+		/// <param name="webinarId">The webinar ID or webinar UUID. If given the webinar ID it will take the last meeting instance.</param>
+		/// <param name="pageSize">The number of records returned within a single API call.</param>
+		/// <param name="pageToken">
+		/// The next page token is used to paginate through large result sets.
+		/// A next page token will be returned whenever the set of available results exceeds the current page size.
+		/// The expiration period for this token is 15 minutes.
+		/// </param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>
+		/// An array of <see cref="ReportWebinarParticipant">participants</see>.
+		/// </returns>
+		Task<PaginatedResponseWithToken<ReportWebinarParticipant>> GetWebinarParticipantsAsync(string webinarId, int pageSize = 30, string pageToken = null, CancellationToken cancellationToken = default);
+
+		/// <summary>
 		/// Gets active/inactive host reports.
 		/// </summary>
 		/// <remarks>

--- a/Source/ZoomNet/Resources/Reports.cs
+++ b/Source/ZoomNet/Resources/Reports.cs
@@ -70,6 +70,20 @@ namespace ZoomNet.Resources
 		}
 
 		/// <inheritdoc/>
+		public Task<PaginatedResponseWithToken<ReportWebinarParticipant>> GetWebinarParticipantsAsync(string webinarId, int pageSize = 30, string pageToken = null, CancellationToken cancellationToken = default)
+		{
+			VerifyPageSize(pageSize);
+
+			return _client
+				   .GetAsync($"report/webinars/{webinarId}/participants")
+				   .WithArgument("include_fields", "registrant_id")
+				   .WithArgument("page_size", pageSize)
+				   .WithArgument("next_page_token", pageToken)
+				   .WithCancellationToken(cancellationToken)
+				   .AsPaginatedResponseWithToken<ReportWebinarParticipant>("participants");
+		}
+
+		/// <inheritdoc/>
 		public Task<PaginatedResponseWithToken<ReportHost>> GetHostsAsync(DateTime from, DateTime to, ReportHostType type = ReportHostType.Active, int pageSize = 30, string pageToken = null, CancellationToken cancellationToken = default)
 		{
 			VerifyReportDatesRange(from, to);


### PR DESCRIPTION
This PR add support for retrieveng the participants report for webinars.

Note that zoom api doesnt have an equivalent for `report/users/{userId}/meetings` for webinars, so i just implemented the `GetWebinarParticipantsAsync` in the `Report` class.

Also modified the integration test.

Fixes #284 