### PR TITLE
Fixing dependencies for .Net6.0

### DIFF
--- a/Source/ZoomNet/ZoomNet.csproj
+++ b/Source/ZoomNet/ZoomNet.csproj
@@ -17,7 +17,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <PackageId>ZoomNet</PackageId>
     <AssemblyName>ZoomNet</AssemblyName>
@@ -38,23 +38,35 @@
   <ItemGroup>
     <PackageReference Include="HttpMultipartParser" Version="8.2.0" />
     <PackageReference Include="jose-jwt" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Pathoschild.Http.FluentClient" Version="4.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Websocket.Client" Version="4.6.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Runtime.Serialization" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">


### PR DESCRIPTION
Due to dependencies taken on 7.0.x versions for System.Text.Json and Microsoft.Extensions.Logging this library was unable to be ran in a .Net 6.0 Azure Functions (~4) application.  This adjusts the versions accordingly and allows for successful consumption by .Net 6.0 applications.

Issue: https://github.com/Jericho/ZoomNet/issues/304