### PR TITLE
Adding pstn enum value for call log transfer extension types.

### DIFF
--- a/Source/ZoomNet/Models/CallLogTransferInfoExtensionType.cs
+++ b/Source/ZoomNet/Models/CallLogTransferInfoExtensionType.cs
@@ -35,6 +35,12 @@ namespace ZoomNet.Models
 		/// sharedLineGroup.
 		/// </summary>
 		[EnumMember(Value = "sharedLineGroup")]
-		SharedLineGroup
+		SharedLineGroup,
+
+		/// <summary>
+		/// pstn.
+		/// </summary>
+		[EnumMember(Value = "pstn")]
+		Pstn
 	}
 }


### PR DESCRIPTION
Issue #305 

Adding the 'pstn' extension type for the `CallLogTransferInfoExtensionType` class