### PR TITLE
Sms resource in ZoomClient

### DIFF
--- a/Source/ZoomNet/IZoomClient.cs
+++ b/Source/ZoomNet/IZoomClient.cs
@@ -122,5 +122,10 @@ namespace ZoomNet
 		/// Gets the resource which allows you to access Zoom Phone API endpoints.
 		/// </summary>
 		IPhone Phone { get; }
+
+		/// <summary>
+		/// Gets the resource which allows you to manage SMS messages and sessions.
+		/// </summary>
+		ISms Sms { get; }
 	}
 }

--- a/Source/ZoomNet/ZoomClient.cs
+++ b/Source/ZoomNet/ZoomClient.cs
@@ -169,6 +169,9 @@ namespace ZoomNet
 		/// <inheritdoc/>
 		public IPhone Phone { get; private set; }
 
+		/// <inheritdoc/>
+		public ISms Sms { get; private set; }
+
 		#endregion
 
 		#region CTOR
@@ -275,6 +278,7 @@ namespace ZoomNet
 			CallLogs = new CallLogs(_fluentClient);
 			Chatbot = new Chatbot(_fluentClient);
 			Phone = new Phone(_fluentClient);
+			Sms = new Sms(_fluentClient);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The new Sms resource was not added to ZoomClient in the last request, which is why it is not available from ZoomClient. 
So this is PR to fix it.