### PR TITLE
Sms.GetSmsSessionDetailsAsync issue

### DIFF
--- a/Source/ZoomNet/Models/SmsAttachmentType.cs
+++ b/Source/ZoomNet/Models/SmsAttachmentType.cs
@@ -28,7 +28,7 @@ namespace ZoomNet.Models
 		/// <summary>
 		/// Jpg.
 		/// </summary>
-		[EnumMember(Value = "JPG")]
+		[EnumMember(Value = "JPG/JPEG")]
 		Jpg,
 
 		/// <summary>

--- a/Source/ZoomNet/Resources/Sms.cs
+++ b/Source/ZoomNet/Resources/Sms.cs
@@ -32,8 +32,8 @@ namespace ZoomNet.Resources
 			return _client
 				.GetAsync($"phone/sms/sessions/{sessionId}")
 				.WithArgument("sort", orderAscending.HasValue ? orderAscending.Value ? 1 : 2 : null)
-				.WithArgument("from", from?.ToZoomFormat(dateOnly: false))
-				.WithArgument("to", to?.ToZoomFormat(dateOnly: false))
+				.WithArgument("from", from?.ToZoomFormat(timeZone: TimeZones.UTC, dateOnly: false))
+				.WithArgument("to", to?.ToZoomFormat(timeZone: TimeZones.UTC, dateOnly: false))
 				.WithArgument("page_size", recordsPerPage)
 				.WithArgument("next_page_token", pagingToken)
 				.WithCancellationToken(cancellationToken)


### PR DESCRIPTION
Sorry, it's me again. 
We need to fix Sms.GetSmsSessionDetailsAsync method. I used wrong formatting (not UTC) parameter for datetime arguments 'to' and 'from' and it doesn't work if we set non-null to these parameters.  

I apologize for bothering you again with this new feature...