### PR TITLE
Issue: The DownloadFileAsync method will throw an OutOfMemoryException if the file is too large

### DIFF
--- a/Source/ZoomNet/Resources/CloudRecordings.cs
+++ b/Source/ZoomNet/Resources/CloudRecordings.cs
@@ -359,17 +359,29 @@ namespace ZoomNet.Resources
 		}
 
 		/// <inheritdoc/>
-		public Task<Stream> DownloadFileAsync(string downloadUrl, CancellationToken cancellationToken = default)
+		public async Task<Stream> DownloadFileAsync(string downloadUrl, CancellationToken cancellationToken = default)
 		{
-			return _client
+			/*
+			 * PLEASE NOTE:
+			 *
+			 * The HttpRequestMessage in this method is dispatched with its completion option set to "ResponseHeadersRead".
+			 * This ensures the content of the response is streamed rather than buffered in memory.
+			 * This is important in cases where the downloaded file is quite large.
+			 * In this scenario, we don't want the entirety of the file to be buffered in a MemoryStream because
+			 * it could lead to "out of memory" exceptions if the file is large enough.
+			 * See https://github.com/Jericho/ZoomNet/pull/342 for a discussion on this topic.
+			 *
+			 * Forthermore, as of this writing, the FluentHttp library does not allow us to stream the content of responses
+			 * which means that the code in this method cannot be simplified like so:
+			 return _client
 				.GetAsync(downloadUrl)
 				.WithCancellationToken(cancellationToken)
 				.AsStream();
-		}
+			 *
+			 * The downside of not using the FluentHttp library to dispatch the request is that we lose automatic retries,
+			 * error handling, logging, etc.
+			 */
 
-		/// <inheritdoc/>
-		public async Task<Stream> DownloadFileWithouBufferingAsync(string downloadUrl, CancellationToken cancellationToken)
-		{
 			using (var request = new HttpRequestMessage(HttpMethod.Get, downloadUrl))
 			{
 				var tokenHandler = _client.Filters.OfType<ITokenHandler>().SingleOrDefault();

--- a/Source/ZoomNet/Resources/CloudRecordings.cs
+++ b/Source/ZoomNet/Resources/CloudRecordings.cs
@@ -368,7 +368,7 @@ namespace ZoomNet.Resources
 		}
 
 		/// <inheritdoc/>
-		public async Task<Stream> DownloadFileWithouBufferingAsync(string downloadUrl)
+		public async Task<Stream> DownloadFileWithouBufferingAsync(string downloadUrl, CancellationToken cancellationToken)
 		{
 			using (var request = new HttpRequestMessage(HttpMethod.Get, downloadUrl))
 			{
@@ -378,7 +378,7 @@ namespace ZoomNet.Resources
 					request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenHandler.Token);
 				}
 
-				var response = await _client.BaseClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+				var response = await _client.BaseClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
 				response.EnsureSuccessStatusCode();
 

--- a/Source/ZoomNet/Resources/ICloudRecordings.cs
+++ b/Source/ZoomNet/Resources/ICloudRecordings.cs
@@ -205,26 +205,13 @@ namespace ZoomNet.Resources
 		Task RejectRegistrantsAsync(long meetingId, IEnumerable<string> registrantIds, CancellationToken cancellationToken = default);
 
 		/// <summary>
-		/// Download the recording file into the memory buffer and return the stream from this buffer.
+		/// Download the recording file.
 		/// </summary>
 		/// <param name="downloadUrl">The URL of the recording file to download.</param>
 		/// <param name="cancellationToken">Cancellation token.</param>
 		/// <returns>
 		/// The <see cref="Stream"/> containing the file.
 		/// </returns>
-		/// <remarks>
-		/// Be careful, because if the recording file is too large, it can lead to buffer overflow and an OutOfMemoryException throwing.
-		/// </remarks>
 		Task<Stream> DownloadFileAsync(string downloadUrl, CancellationToken cancellationToken = default);
-
-		/// <summary>
-		/// Download the recording file without buffering.
-		/// </summary>
-		/// <param name="downloadUrl">The URL of the recording file to download.</param>
-		/// <param name="cancellationToken">Cancellation token.</param>
-		/// <returns>
-		/// The <see cref="Stream"/> containing the file.
-		/// </returns>
-		Task<Stream> DownloadFileWithouBufferingAsync(string downloadUrl, CancellationToken cancellationToken = default);
 	}
 }

--- a/Source/ZoomNet/Resources/ICloudRecordings.cs
+++ b/Source/ZoomNet/Resources/ICloudRecordings.cs
@@ -221,9 +221,10 @@ namespace ZoomNet.Resources
 		/// Download the recording file without buffering.
 		/// </summary>
 		/// <param name="downloadUrl">The URL of the recording file to download.</param>
+		/// <param name="cancellationToken">Cancellation token.</param>
 		/// <returns>
 		/// The <see cref="Stream"/> containing the file.
 		/// </returns>
-		Task<Stream> DownloadFileWithouBufferingAsync(string downloadUrl);
+		Task<Stream> DownloadFileWithouBufferingAsync(string downloadUrl, CancellationToken cancellationToken = default);
 	}
 }

--- a/Source/ZoomNet/Resources/ICloudRecordings.cs
+++ b/Source/ZoomNet/Resources/ICloudRecordings.cs
@@ -205,13 +205,25 @@ namespace ZoomNet.Resources
 		Task RejectRegistrantsAsync(long meetingId, IEnumerable<string> registrantIds, CancellationToken cancellationToken = default);
 
 		/// <summary>
-		/// Download the recording file.
+		/// Download the recording file into the memory buffer and return the stream from this buffer.
 		/// </summary>
 		/// <param name="downloadUrl">The URL of the recording file to download.</param>
 		/// <param name="cancellationToken">Cancellation token.</param>
 		/// <returns>
 		/// The <see cref="Stream"/> containing the file.
 		/// </returns>
+		/// <remarks>
+		/// Be careful, because if the recording file is too large, it can lead to buffer overflow and an OutOfMemoryException throwing.
+		/// </remarks>
 		Task<Stream> DownloadFileAsync(string downloadUrl, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Download the recording file without buffering.
+		/// </summary>
+		/// <param name="downloadUrl">The URL of the recording file to download.</param>
+		/// <returns>
+		/// The <see cref="Stream"/> containing the file.
+		/// </returns>
+		Task<Stream> DownloadFileWithouBufferingAsync(string downloadUrl);
 	}
 }


### PR DESCRIPTION
I found an issue when we use the DownloadFileAsync method. Since it uses IRequest.AsStream(), this method invokes HttpClient.SendAsync(request, cancellationtoken) and than HttpResponseMessage.Content.ReadAsStreamAsync() for the response message. 
The HttpResponseMessage.Content.ReadAsStreamAsync() read whole content into the memory buffer and makes the stream from result buffer.

In our project we encountered with following issue: if we receive a large enough file, buffer can overflow.

But I also found (here [Streaming Large HTTP Responses](https://www.tugberkugurlu.com/archive/efficiently-streaming-large-http-responses-with-httpclient)) if we call HttpClient.SendAsync with HttpCompletionOption.ResponseHeadersRead flag it just return stream without buffering and we can handle received stream as we want.

So I suggest to use old implementation of DownloadFileAsync in new method, but with HttpCompletionOption.ResponseHeadersRead flag.

May we also need to create issue in [Pathoschild](https://github.com/Pathoschild/FluentHttpClient/issues) repository.