### PR TITLE
Fix PresenceStatus enum member values

### DIFF
--- a/Source/ZoomNet/Models/PresenceStatus.cs
+++ b/Source/ZoomNet/Models/PresenceStatus.cs
@@ -40,7 +40,7 @@ namespace ZoomNet.Models
 		/// <summary>
 		/// In calendar event.
 		/// </summary>
-		[EnumMember(Value = "In_Calendar_Event")]
+		[EnumMember(Value = "In_A_Calendar_Event")]
 		InEvent,
 
 		/// <summary>
@@ -52,13 +52,13 @@ namespace ZoomNet.Models
 		/// <summary>
 		/// In a Zoom meeting.
 		/// </summary>
-		[EnumMember(Value = "In_A_Zoom_Meeting")]
+		[EnumMember(Value = "In_A_Meeting")]
 		InMeeting,
 
 		/// <summary>
 		/// On a call.
 		/// </summary>
-		[EnumMember(Value = "On_A_Call")]
+		[EnumMember(Value = "In_A_Call")]
 		OnCall,
 
 		/// <summary>


### PR DESCRIPTION
After working in real life with [Get user presence status](https://developers.zoom.us/docs/api/users/#tag/users/GET/users/{userId}/presence_status) endpoint we noticed that actual status values are different in three cases:
In_Calendar_Event -> In_A_Calendar_Event
In_A_Zoom_Meeting -> In_A_Meeting
On_A_Call -> In_A_Call

It seems that values from the bullet list were initially added to PresenceStatus enum whereas real values are the ones given in the bold text:
![image](https://github.com/user-attachments/assets/8e46ec59-adf9-485c-afef-768bce18d828)
