### PR TITLE
Add endpoint for getting specific message from SMS session

### DIFF
--- a/Source/ZoomNet/Resources/ISms.cs
+++ b/Source/ZoomNet/Resources/ISms.cs
@@ -30,5 +30,18 @@ namespace ZoomNet.Resources
 		/// Zoom endpoint documentation</a> for more information.
 		/// </remarks>
 		Task<PaginatedResponseWithToken<SmsMessage>> GetSmsSessionDetailsAsync(string sessionId, DateTime? from, DateTime? to, bool? orderAscending = true, int recordsPerPage = 30, string pagingToken = null, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Get details about a specific message in an SMS session.
+		/// </summary>
+		/// <param name="sessionId">SMS session ID.</param>
+		/// <param name="messageId">SMS message ID.</param>
+		/// <param name="cancellation">The cancellation token.</param>
+		/// <returns>Specific message from SMS session.</returns>
+		/// <remarks>
+		/// See <a href="https://developers.zoom.us/docs/api/rest/reference/phone/methods/#operation/smsByMessageId">
+		/// Zoom endpoint documentation</a> for more information.
+		/// </remarks>
+		Task<SmsMessage> GetSmsByMessageIdAsync(string sessionId, string messageId, CancellationToken cancellation = default);
 	}
 }

--- a/Source/ZoomNet/Resources/Sms.cs
+++ b/Source/ZoomNet/Resources/Sms.cs
@@ -37,5 +37,15 @@ namespace ZoomNet.Resources
 				.WithCancellationToken(cancellationToken)
 				.AsPaginatedResponseWithToken<SmsMessage>("sms_histories");
 		}
+
+		/// <inheritdoc/>
+		public Task<SmsMessage> GetSmsByMessageIdAsync(
+			string sessionId, string messageId, CancellationToken cancellationToken = default)
+		{
+			return _client
+				.GetAsync($"phone/sms/sessions/{sessionId}/messages/{messageId}")
+				.WithCancellationToken(cancellationToken)
+				.AsObject<SmsMessage>();
+		}
 	}
 }


### PR DESCRIPTION
Added endpoint for getting specific message from SMS session.
Uses the same SmsMessage data model as endpoint for getting messages list from SMS session.
Endpoint implementation is verified in local project.